### PR TITLE
Feature/Budget-input

### DIFF
--- a/apps/client/app/budget/input/page.tsx
+++ b/apps/client/app/budget/input/page.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import BudgetDescription from '@/src/widgets/budget/input/BudgetDescription';
+import BudgetInput from '@/src/widgets/budget/input/BudgetInput';
+import { useState } from 'react';
+
+export default function BudgetInputPage() {
+  const [budget, setBudget] = useState(0);
+
+  // TODO
+  const saveBudget = () => {
+    // api
+  };
+
+  const backHistory = () => {
+    //
+  };
+
+  return (
+    <main className="h-full">
+      {/* TODO - Header로 바꿀 예정 */}
+      <header className="h-[56px]">Header</header>
+      <BudgetDescription />
+      <BudgetInput budget={budget} onChange={setBudget} />
+    </main>
+  );
+}

--- a/apps/client/jest.setup.js
+++ b/apps/client/jest.setup.js
@@ -1,6 +1,9 @@
 import '@testing-library/jest-dom';
+import 'jest-plugin-context';
+import 'jest-plugin-context/setup';
 
 import { server } from './mocks/server';
+
 beforeAll(() => server.listen());
 
 afterEach(() => server.resetHandlers());

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -12,11 +12,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@wepl/ui": "*",
-    "autoprefixer": "^10.4.19",
-    "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.3",
-    "undici": "^5.0.0"
+    "@wepl/ui": "*"
   },
   "devDependencies": {
     "@wepl/eslint-config": "*",

--- a/apps/client/src/app/AppLayout.tsx
+++ b/apps/client/src/app/AppLayout.tsx
@@ -4,7 +4,7 @@ import { QueryProvider } from './QueryProvider';
 export function AppLayout({ children }: { children: React.ReactNode }): JSX.Element {
   return (
     <QueryProvider>
-      <div className="relative m-auto border-l-2 border-r-2 border-green-500 max-w-full min-w-[365px] md:max-w-[760px] h-screen ">
+      <div className="relative m-auto px-[40px] sm:px-[20px] border-l-2 border-r-2 border-green-500 max-w-[768px] md:max-w-full min-w-[360px] h-screen ">
         {children}
       </div>
     </QueryProvider>

--- a/apps/client/src/widgets/budget/input/BudgetDescription.tsx
+++ b/apps/client/src/widgets/budget/input/BudgetDescription.tsx
@@ -1,0 +1,8 @@
+export default function BudgetDescription() {
+  return (
+    <div>
+      <h1 className="text-[#333333] text-xl leading-7 font-bold">총 결혼준비 비용</h1>
+      <p className="mt-[2px] text-[#7f7f88] text-sm leading-5 font-normal">생각하신 결혼준비 비용을 작성해주세요.</p>
+    </div>
+  );
+}

--- a/apps/client/src/widgets/budget/input/BudgetInput.test.tsx
+++ b/apps/client/src/widgets/budget/input/BudgetInput.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BudgetInput from './BudgetInput';
+
+describe('BudgetInput', () => {
+  context('budget에 대하여', () => {
+    it('budget > 0 이면, 금액과 쉼표, 원을 렌더링한다.', () => {
+      const budget = 10000;
+      const unit = '원';
+      render(<BudgetInput budget={budget} onChange={() => {}} />);
+
+      expect(screen.getByRole('textbox')).toHaveValue(budget.toLocaleString());
+      expect(screen.getByText(unit)).toBeInTheDocument();
+    });
+
+    it('budget === 0 이면, placeholder 값을 보여준다.', () => {
+      render(<BudgetInput budget={0} onChange={() => {}} />);
+
+      expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', '예산을 입력해주세요');
+    });
+  });
+
+  it('Inputbox에 타이핑하면, onChange 핸들러가 실행되어야 한다.', async () => {
+    const user = userEvent.setup();
+    const handleChange = jest.fn();
+
+    const { getByRole } = render(<BudgetInput budget={0} onChange={handleChange} />);
+
+    await user.type(getByRole('textbox'), '20000');
+    expect(handleChange).toHaveBeenCalled();
+  });
+});

--- a/apps/client/src/widgets/budget/input/BudgetInput.tsx
+++ b/apps/client/src/widgets/budget/input/BudgetInput.tsx
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+
+interface BudgetInputProps {
+  budget: number;
+  onChange: React.Dispatch<React.SetStateAction<number>>;
+}
+
+export default function BudgetInput({ budget, onChange }: BudgetInputProps) {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value.replace(/[^0-9,]/g, '');
+      const number = Number(value.replaceAll(',', ''));
+
+      // 입력값(결혼비용)이 1조보다 크면 무시
+      if (number > 10e11) return;
+
+      onChange(number);
+    },
+    [onChange],
+  );
+
+  return (
+    <div className="mt-[40px] flex items-center text-[28px] font-bold">
+      <input
+        type="text"
+        value={budget > 0 ? budget.toLocaleString() : ''}
+        className="outline-none placeholder:text-[#d9d9d9] after:content-['원']"
+        placeholder="예산을 입력해주세요"
+        onChange={handleChange}
+      />
+      <span>{budget && budget >= 0 ? '원' : ''}</span>
+    </div>
+  );
+}

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -22,7 +22,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts", "jest.setup.js",
   ],
   "exclude": [
     "node_modules"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@testing-library/react": "^15.0.6",
         "@testing-library/user-event": "^14.5.2",
         "@types/jest": "^29.5.12",
+        "@types/jest-plugin-context": "^2.9.7",
         "@types/node": "^20.11.24",
         "@types/qs": "^6.9.15",
         "@types/react": "^18.2.61",
@@ -43,13 +44,15 @@
         "eslint-plugin-testing-library": "^6.2.2",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "jest-plugin-context": "^2.9.0",
         "msw": "^2.2.14",
         "postcss": "^8.4.35",
         "prettier": "^3.2.5",
         "prettier-plugin-tailwindcss": "^0.5.11",
         "ts-jest": "^29.1.2",
         "turbo": "latest",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "undici": "^6.18.2"
       },
       "engines": {
         "node": ">=18"
@@ -58,27 +61,12 @@
     "apps/client": {
       "version": "1.0.0",
       "dependencies": {
-        "@wepl/ui": "*",
-        "autoprefixer": "^10.4.19",
-        "postcss": "^8.4.38",
-        "tailwindcss": "^3.4.3",
-        "undici": "^5.0.0"
+        "@wepl/ui": "*"
       },
       "devDependencies": {
         "@wepl/eslint-config": "*",
         "@wepl/tailwind-config": "*",
         "@wepl/typescript-config": "*"
-      }
-    },
-    "apps/client/node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.0"
       }
     },
     "apps/docs": {
@@ -2204,14 +2192,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -3555,6 +3535,15 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jest-plugin-context": {
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/@types/jest-plugin-context/-/jest-plugin-context-2.9.7.tgz",
+      "integrity": "sha512-olZlorLxJPZwviMXP410fEX34ATv/O4lFR3jymgQvi32I36flNDukZ369n1PEWqa7v26ZiSslVoyT9hdvRyP9w==",
+      "dev": true,
+      "dependencies": {
+        "@types/jest": "*"
+      }
+    },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -4407,6 +4396,7 @@
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
       "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4669,6 +4659,7 @@
       "version": "4.23.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
       "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5456,7 +5447,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.746",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.746.tgz",
-      "integrity": "sha512-jeWaIta2rIG2FzHaYIhSuVWqC6KJYo7oSBX4Jv7g+aVujKztfvdpf+n6MGwZdC5hQXbax4nntykLH2juIQrfPg=="
+      "integrity": "sha512-jeWaIta2rIG2FzHaYIhSuVWqC6KJYo7oSBX4Jv7g+aVujKztfvdpf+n6MGwZdC5hQXbax4nntykLH2juIQrfPg==",
+      "dev": true
     },
     "node_modules/embla-carousel": {
       "version": "8.1.3",
@@ -5694,6 +5686,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -6899,6 +6892,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
       "engines": {
         "node": "*"
       },
@@ -8335,6 +8329,15 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-plugin-context": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/jest-plugin-context/-/jest-plugin-context-2.9.0.tgz",
+      "integrity": "sha512-soBudNt3oTgeSFhRzLY2BwZdVuAlJ29zraNqt+PVRogkTPzNdvxIT3b0JXHQZUnT3jNsoNhTY9EDnGsyO2ExAg==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": "*"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -9291,7 +9294,8 @@
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -9326,6 +9330,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11928,6 +11933,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.18.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
+      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
@@ -11987,6 +12001,7 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@testing-library/react": "^15.0.6",
     "@testing-library/user-event": "^14.5.2",
     "@types/jest": "^29.5.12",
+    "@types/jest-plugin-context": "^2.9.7",
     "@types/node": "^20.11.24",
     "@types/qs": "^6.9.15",
     "@types/react": "^18.2.61",
@@ -46,13 +47,15 @@
     "eslint-plugin-testing-library": "^6.2.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jest-plugin-context": "^2.9.0",
     "msw": "^2.2.14",
     "postcss": "^8.4.35",
     "prettier": "^3.2.5",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "ts-jest": "^29.1.2",
     "turbo": "latest",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "undici": "^6.18.2"
   },
   "engines": {
     "node": ">=18"

--- a/packages/config-tailwind/tailwind.config.ts
+++ b/packages/config-tailwind/tailwind.config.ts
@@ -11,16 +11,11 @@ const config: Config = {
   ],
   prefix: '',
   theme: {
-    container: {
-      center: true,
-      padding: '2rem',
-      screens: {
-        '2xl': '1535px',
-        xl: { max: '1279px' },
-        lg: { max: '1023px' },
-        md: { max: '767px' },
-        sm: { max: '359px' },
-      },
+    screens: {
+      xl: { max: '1535px' },
+      lg: { max: '1279px' },
+      md: { max: '1023px' },
+      sm: { max: '767px' },
     },
     extend: {
       colors: {

--- a/packages/ui/jest.setup.js
+++ b/packages/ui/jest.setup.js
@@ -1,1 +1,3 @@
 import '@testing-library/jest-dom';
+import 'jest-plugin-context';
+import 'jest-plugin-context/setup';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -11,5 +11,5 @@
       "@ui/*": ["./*"]
     }
   },
-  "include": [".", "src", "jest.setup.js"]
+  "include": [".", "src", "./jest.setup.js"]
 }


### PR DESCRIPTION
1. jest-plugin-context 를 app/client와 packages/ui 환경에 추가했습니다.
describe - it 외에 describe - context - it (DCI) 패턴으로 테스트 코드를 작성할 수 있습니다.
describe - describe - it 형태로 describe를 중첩해서 사용할 수 있지만,
DCI 패턴에 비해 직관적이지 않아 보입니다.
- describe : 테스트할 컴포넌트 대상 (컴포넌트 이름)
- context : 어떤 상황 또는 조건
- it : 기대하는 동작을 명시

<br/>

2. 예산 입력 페이지를 대략 구현했습니다.
FSD 디자인 패턴에 의해, widgets을 페이지별 컴포넌트를 관리하는 공간이라고 생각했고,
/budget/input URL에 예산 입력 페이지를 할당했습니다.
- TDD 방식으로 진행했습니다.

<br/>

3. tailwind 설정 수정
container 관련 속성을 제거했습니다. (컨테이너, container를 굳이 클래스로 관리할 필요가 없어 보여서)
breakpoint를 수정했습니다.

- sm (모바일) ~767px까지  (max-width 기준이므로)
- md (태블릿) ~ 1023px까지
...


<br/>

[예산 입력 화면 동작]

https://github.com/Side-Project-Since-04/wepl-fe/assets/24875185/e3821ae9-677c-408f-92b3-d04c533930ce









